### PR TITLE
Add option for JWT string from ENV var

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ $ bash make.sh build_linux
 | ----------------|------------------------------------------------|----------------|
 | Project         | google cloud project id | NONE(required) |
 | Topic           | google pubsub topic name | NONE(required) |
-| JwtPath         | jwt file path for accessible google cloud project | NONE(required) |
+| Jwt             | jwt string for accessible google cloud project (expected to be stored from ENV) | NONE(Jwt or JwtPath required) |
+| JwtPath         | jwt file path for accessible google cloud project | NONE(Jwt or JwtPath required) |
 | Debug           | print debug log | false(optional) |
 | Timeout         | the maximum time that the client will attempt to publish a bundle of messages. (millsecond) | 60000 (optional)|
 | DelayThreshold  | publish a non-empty batch after this delay has passed. (millsecond) | 1  |

--- a/output_pubsub.go
+++ b/output_pubsub.go
@@ -19,6 +19,7 @@ var (
 	plugin   Keeper
 	hostname string
 	wrapper  = OutputWrapper(&Output{})
+	secret   Secret
 
 	timeout        = pubsub.DefaultPublishSettings.Timeout
 	delayThreshold = pubsub.DefaultPublishSettings.DelayThreshold
@@ -29,6 +30,11 @@ var (
 	schemaType       pubsub.SchemaType
 	schemaDefinition string
 )
+
+type Secret struct {
+	jwtPath string
+	jwt     string
+}
 
 type Output struct{}
 
@@ -65,7 +71,8 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 	var err error
 	project := wrapper.GetConfigKey(ctx, "Project")
 	topic := wrapper.GetConfigKey(ctx, "Topic")
-	jwtPath := wrapper.GetConfigKey(ctx, "JwtPath")
+	secret.jwt = wrapper.GetConfigKey(ctx, "Jwt")
+	secret.jwtPath = wrapper.GetConfigKey(ctx, "JwtPath")
 	dg := wrapper.GetConfigKey(ctx, "Debug")
 	to := wrapper.GetConfigKey(ctx, "Timeout")
 	bt := wrapper.GetConfigKey(ctx, "ByteThreshold")
@@ -76,7 +83,8 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 
 	fmt.Printf("[pubsub-go] plugin parameter project = '%s'\n", project)
 	fmt.Printf("[pubsub-go] plugin parameter topic = '%s'\n", topic)
-	fmt.Printf("[pubsub-go] plugin parameter jwtPath = '%s'\n", jwtPath)
+	fmt.Printf("[pubsub-go] plugin parameter jwt = ****\n")
+	fmt.Printf("[pubsub-go] plugin parameter jwtPath = '%s'\n", secret.jwtPath)
 	fmt.Printf("[pubsub-go] plugin parameter debug = '%s'\n", dg)
 	fmt.Printf("[pubsub-go] plugin parameter timeout = '%s'\n", to)
 	fmt.Printf("[pubsub-go] plugin parameter byte threshold = '%s'\n", bt)
@@ -163,7 +171,7 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 		Definition: schemaDefinition,
 	}
 
-	keeper, err := NewKeeper(project, topic, jwtPath, &publishSetting, &schemaConfig)
+	keeper, err := NewKeeper(project, topic, &secret, &publishSetting, &schemaConfig)
 	if err != nil {
 		fmt.Printf("[err][init] %+v\n", err)
 		return output.FLB_ERROR

--- a/output_pubsub_test.go
+++ b/output_pubsub_test.go
@@ -93,7 +93,8 @@ func TestFLBPluginFlush(t *testing.T) {
 	if projectId == "" || topicName == "" || jwtPath == "" {
 		return
 	}
-	keeper, err := NewKeeper(projectId, topicName, jwtPath, nil, nil)
+	secret := Secret{"", jwtPath}
+	keeper, err := NewKeeper(projectId, topicName, &secret, nil, nil)
 	assert.NoError(err)
 	sub := keeper.(*GooglePubSub).client.Subscription(topicName)
 	go func() {

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -15,8 +15,9 @@ import (
 func TestNewKeeper(t *testing.T) {
 	assert := assert.New(t)
 
+	secret := Secret{"", ""}
 	// Invalid setting
-	_, err := NewKeeper("", "", "", nil, nil)
+	_, err := NewKeeper("", "", &secret, nil, nil)
 	assert.Error(err)
 
 	// minimum settings
@@ -26,12 +27,12 @@ func TestNewKeeper(t *testing.T) {
 	if projectId == "" || topicName == "" || jwtPath == "" {
 		return
 	}
-
-	_, err = NewKeeper(projectId, topicName, jwtPath, nil, nil)
+	secret = Secret{"", jwtPath}
+	_, err = NewKeeper(projectId, topicName, &secret, nil, nil)
 	assert.NoError(err)
 
 	// add publish settings (optional)
-	keeper, err := NewKeeper(projectId, topicName, jwtPath, &pubsub.PublishSettings{
+	keeper, err := NewKeeper(projectId, topicName, &secret, &pubsub.PublishSettings{
 		ByteThreshold:  10,
 		CountThreshold: 10,
 		DelayThreshold: 1 * time.Second,
@@ -43,7 +44,7 @@ func TestNewKeeper(t *testing.T) {
 	assert.Equal(keeper.(*GooglePubSub).topic.PublishSettings.CountThreshold, 10)
 	assert.Equal(keeper.(*GooglePubSub).topic.PublishSettings.ByteThreshold, 10)
 
-	_, err = NewKeeper(projectId, topicName, jwtPath, nil, nil)
+	_, err = NewKeeper(projectId, topicName, &secret, nil, nil)
 	assert.NoError(err)
 
 	// add Avro schema settings (optional)
@@ -53,7 +54,7 @@ func TestNewKeeper(t *testing.T) {
 		Definition: "",
 	}
 
-	keeper, err = NewKeeper(projectId, topicName, jwtPath, nil, avroConfig)
+	keeper, err = NewKeeper(projectId, topicName, &secret, nil, avroConfig)
 	assert.NoError(err)
 	//assert.Equal(keeper.(*GooglePubSub).topic.PublishSettings.Timeout, 5*time.Second)
 	//assert.Equal(keeper.(*GooglePubSub).topic.PublishSettings.DelayThreshold, 1*time.Second)
@@ -65,7 +66,7 @@ func TestNewKeeper(t *testing.T) {
 		Definition: "",
 	}
 
-	keeper, err = NewKeeper(projectId, topicName, jwtPath, nil, protobufConfig)
+	keeper, err = NewKeeper(projectId, topicName, &secret, nil, protobufConfig)
 	assert.NoError(err)
 	//assert.Equal(keeper.(*GooglePubSub).topic.PublishSettings.Timeout, 5*time.Second)
 	//assert.Equal(keeper.(*GooglePubSub).topic.PublishSettings.DelayThreshold, 1*time.Second)
@@ -81,9 +82,9 @@ func TestGooglePubSub_Send(t *testing.T) {
 	if projectId == "" || topicName == "" || jwtPath == "" {
 		return
 	}
-
+	secret = Secret{"", jwtPath}
 	ctx := context.Background()
-	keeper, err := NewKeeper(projectId, topicName, jwtPath, nil, nil)
+	keeper, err := NewKeeper(projectId, topicName, &secret, nil, nil)
 	assert.NoError(err)
 
 	result := keeper.Send(ctx, []byte("aaa"))
@@ -108,8 +109,8 @@ func TestGooglePubSub_Stop(t *testing.T) {
 	if projectId == "" || topicName == "" || jwtPath == "" {
 		return
 	}
-
-	keeper, err := NewKeeper(projectId, topicName, jwtPath, nil, nil)
+	secret = Secret{"", jwtPath}
+	keeper, err := NewKeeper(projectId, topicName, &secret, nil, nil)
 	assert.NoError(err)
 	keeper.Stop()
 }


### PR DESCRIPTION
Add GCP JWT options to the configuration.

Secret should not be placed in a container image.
It is standard practice to pass Secret via environment variables.

The existing config method as specifying the JWT path is retained, but the config method as using a environment variable can be handled as well. However, the environment variable method has priority over the path method.