### PR TITLE
Feature/support union type in avro schema

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -9,8 +9,8 @@ CURRENT=`pwd`
 function build
 {
    go build -buildmode=c-shared -o pubsub.so .
-   local osname=`go env | grep GOOS | awk -F "=" '{print $2}' | sed 's/\"//g'`
-   local archname=`go env | grep GOARCH | awk -F "=" '{print $2}' | sed 's/\"//g'`
+   local osname=`go env | grep GOOS | awk -F "=" '{print $2}' | sed "s/['\"]//g"`
+   local archname=`go env | grep GOARCH | awk -F "=" '{print $2}' | sed "s/['\"]//g"`
    mkdir -p $CURRENT/bin/${osname}_${archname} || true
    mv pubsub.so pubsub.h $CURRENT/bin/${osname}_${archname}/
 }

--- a/output_pubsub.go
+++ b/output_pubsub.go
@@ -200,8 +200,8 @@ func FLBPluginFlush(data unsafe.Pointer, length C.int, tag *C.char) int {
 		}
 		timestamp := ts.(output.FLBTime)
 
-		if schemaType == pubsub.SchemaAvro || schemaType == pubsub.SchemaProtocolBuffer {
-			r, err := plugin.InterfaceMapToByte(record)
+		if schemaType == pubsub.SchemaAvro {
+			r, err := plugin.ConvertAvroNative(record)
 			if err != nil {
 				fmt.Printf("[err][publish][don't retry] %+v \n", err)
 			}


### PR DESCRIPTION
For https://github.com/ragi256/fluent-bit-pubsub/pull/1 , I add feature for custom schema in Pub/Sub.

On custom schema of Avro schema, Avro support many data type such as [primitive types](https://avro.apache.org/docs/1.11.1/specification/#primitive-types) and [complex types](https://avro.apache.org/docs/1.11.1/specification/#complex-types).
([Cloud Pub/Sub support/ Avro version 1.11](https://cloud.google.com/pubsub/docs/schemas#types-schema))

In logs such as FluentBit, Nullable is important in the schema.
In Avro data types, this is represented as a union type with null.

For this reason, I have added support for union types in custom schemas using Avro.
This required the use of `goavro.Union` and type reflection in Go.

TODO
- support ProtoBuf 
- split module to Avro and ProtoBuf
- use pstest for test