### PR TITLE
Fix initialize NewKeeper without SchemaType

### DIFF
--- a/output_pubsub.go
+++ b/output_pubsub.go
@@ -166,12 +166,15 @@ func FLBPluginInit(ctx unsafe.Pointer) int {
 		DelayThreshold: delayThreshold,
 		Timeout:        timeout,
 	}
-	schemaConfig := pubsub.SchemaConfig{
-		Type:       schemaType,
-		Definition: schemaDefinition,
+	var schemaConfig *pubsub.SchemaConfig
+	if st != "" && sfp == "" {
+		schemaConfig = &pubsub.SchemaConfig{
+			Type:       schemaType,
+			Definition: schemaDefinition,
+		}
 	}
 
-	keeper, err := NewKeeper(project, topic, &secret, &publishSetting, &schemaConfig)
+	keeper, err := NewKeeper(project, topic, &secret, &publishSetting, schemaConfig)
 	if err != nil {
 		fmt.Printf("[err][init] %+v\n", err)
 		return output.FLB_ERROR


### PR DESCRIPTION
If FluentBit config was without `SchemaType`, a runtime error would occur during initilize NewKeeper. 
`encoding` in pubsub.go:95 is always required, so that this error  happend.

```go
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x7ff611917cda]
"goroutine 17 [running, locked to thread]:"
"main.NewKeeper({0x4c0002f4fe0, 0x7}, {0x4c00013f710, 0x21}, 0x4c000070d00?, 0x4c0004f7bf0, 0x4c000509dc0)"
	/go/fluent-bit-pubsub/pubsub.go:95 +0x4da
main.FLBPluginInit(0x4c000006601?)
	/go/fluent-bit-pubsub/output_pubsub.go:174 +0xe65
```

`/go/fluent-bit-pubsub/pubsub.go:95`
https://github.com/ragi256/fluent-bit-pubsub/blob/acb8dd7a9ee6279fb803e84aff2dcc48b5d31b7f/pubsub.go#L95